### PR TITLE
Add bucket and IAM roles for cloud cost management

### DIFF
--- a/global/README.md
+++ b/global/README.md
@@ -42,7 +42,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key | `string` | n/a | yes |
-| <a name="input_cloud_cost_management_bucket_location"></a> [cloud\_cost\_management\_bucket\_location](#input\_cloud\_cost\_management\_bucket\_location) | The location for the cloud cost management bucket, only used if enable\_cloud\_cost\_management is true | `string` | `"US"` | no |
+| <a name="input_cloud_cost_management_location"></a> [cloud\_cost\_management\_location](#input\_cloud\_cost\_management\_location) | The location for the cloud cost management bucket and Bigquery dataset, only used if enable\_cloud\_cost\_management is true | `string` | `"US"` | no |
 | <a name="input_cost_center"></a> [cost\_center](#input\_cost\_center) | The cost center to use for resource labels | `string` | n/a | yes |
 | <a name="input_enable_cloud_cost_management"></a> [enable\_cloud\_cost\_management](#input\_enable\_cloud\_cost\_management) | Whether Datadog collects cloud cost management data from your GCP project, this should only be set to true in a single project | `bool` | `false` | no |
 | <a name="input_is_cspm_enabled"></a> [is\_cspm\_enabled](#input\_is\_cspm\_enabled) | Whether Datadog collects cloud security posture management resources from your GCP project | `bool` | `false` | no |

--- a/global/README.md
+++ b/global/README.md
@@ -12,7 +12,8 @@ No requirements.
 | Name | Version |
 |------|---------|
 | <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.36.1 |
-| <a name="provider_google"></a> [google](#provider\_google) | 5.17.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.18.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
 
@@ -24,19 +25,24 @@ No modules.
 |------|------|
 | [datadog_integration_gcp_sts.this](https://registry.terraform.io/providers/datadog/datadog/latest/docs/resources/integration_gcp_sts) | resource |
 | [google_bigquery_dataset.billing_export](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset) | resource |
+| [google_bigquery_dataset_iam_member.cloud_cost_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset_iam_member) | resource |
 | [google_logging_project_sink.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_project_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_topic.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_pubsub_topic_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
 | [google_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_member.service_account_token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_storage_bucket.cloud_cost_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_member.cloud_cost_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key | `string` | n/a | yes |
+| <a name="input_cloud_cost_management_bucket_location"></a> [cloud\_cost\_management\_bucket\_location](#input\_cloud\_cost\_management\_bucket\_location) | The location for the cloud cost management bucket, only used if enable\_cloud\_cost\_management is true | `string` | `"US"` | no |
 | <a name="input_cost_center"></a> [cost\_center](#input\_cost\_center) | The cost center to use for resource labels | `string` | n/a | yes |
 | <a name="input_enable_cloud_cost_management"></a> [enable\_cloud\_cost\_management](#input\_enable\_cloud\_cost\_management) | Whether Datadog collects cloud cost management data from your GCP project, this should only be set to true in a single project | `bool` | `false` | no |
 | <a name="input_is_cspm_enabled"></a> [is\_cspm\_enabled](#input\_is\_cspm\_enabled) | Whether Datadog collects cloud security posture management resources from your GCP project | `bool` | `false` | no |

--- a/global/main.tf
+++ b/global/main.tf
@@ -28,7 +28,9 @@ resource "google_bigquery_dataset" "billing_export" {
   description   = "Cloud Billing data to export to BigQuery"
   friendly_name = "Billing Export"
   labels        = local.labels
-  project       = var.project
+  location      = var.cloud_cost_management_location
+
+  project = var.project
 }
 
 # Google BigQuery Dataset IAM Member Resource
@@ -71,7 +73,7 @@ resource "google_storage_bucket" "cloud_cost_management" {
   count = var.enable_cloud_cost_management ? 1 : 0
 
   labels                      = local.labels
-  location                    = var.cloud_cost_management_bucket_location
+  location                    = var.cloud_cost_management_location
   name                        = "datadog-cloud-cost-management-${random_id.this.hex}"
   project                     = var.project
   uniform_bucket_level_access = true

--- a/global/main.tf
+++ b/global/main.tf
@@ -161,5 +161,5 @@ resource "google_pubsub_topic_iam_member" "this" {
 
 resource "random_id" "this" {
   prefix      = "tf"
-  byte_length = "1"
+  byte_length = "2"
 }

--- a/global/variables.tf
+++ b/global/variables.tf
@@ -9,6 +9,12 @@ variable "cost_center" {
   type        = string
 }
 
+variable "cloud_cost_management_bucket_location" {
+  description = "The location for the cloud cost management bucket, only used if enable_cloud_cost_management is true"
+  type        = string
+  default     = "US"
+}
+
 variable "enable_cloud_cost_management" {
   description = "Whether Datadog collects cloud cost management data from your GCP project, this should only be set to true in a single project"
   type        = bool

--- a/global/variables.tf
+++ b/global/variables.tf
@@ -9,8 +9,8 @@ variable "cost_center" {
   type        = string
 }
 
-variable "cloud_cost_management_bucket_location" {
-  description = "The location for the cloud cost management bucket, only used if enable_cloud_cost_management is true"
+variable "cloud_cost_management_location" {
+  description = "The location for the cloud cost management bucket and Bigquery dataset, only used if enable_cloud_cost_management is true"
   type        = string
   default     = "US"
 }

--- a/test/fixtures/default_integration/infracost-usage.yml
+++ b/test/fixtures/default_integration/infracost-usage.yml
@@ -18,6 +18,17 @@ resource_type_default_usage:
   ##
   # google_bigquery_dataset:
     # monthly_queries_tb: 0.0 # Monthly number of bytes processed (also referred to as bytes read) in TB.
+  # google_storage_bucket:
+    # storage_gb: 0.0 # Total size of bucket in GB.
+    # monthly_class_a_operations: 0 # Monthly number of class A operations (object adds, bucket/object list).
+    # monthly_class_b_operations: 0 # Monthly number of class B operations (object gets, retrieve bucket/object metadata).
+    # monthly_data_retrieval_gb: 0.0 # Monthly amount of data retrieved in GB.
+    # monthly_egress_data_transfer_gb:
+      # same_continent: 0.0 # Same continent.
+      # worldwide: 0.0 # Worldwide excluding Asia, Australia.
+      # asia: 0.0 # Asia excluding China, but including Hong Kong.
+      # china: 0.0 # China excluding Hong Kong.
+      # australia: 0.0 # Australia.
 # resource_usage:
   ##
   ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
@@ -25,6 +36,17 @@ resource_type_default_usage:
   ##
   # module.test.google_bigquery_dataset.billing_export[0]:
     # monthly_queries_tb: 0.0 # Monthly number of bytes processed (also referred to as bytes read) in TB.
+  # module.test.google_storage_bucket.cloud_cost_management[0]:
+    # storage_gb: 0.0 # Total size of bucket in GB.
+    # monthly_class_a_operations: 0 # Monthly number of class A operations (object adds, bucket/object list).
+    # monthly_class_b_operations: 0 # Monthly number of class B operations (object gets, retrieve bucket/object metadata).
+    # monthly_data_retrieval_gb: 0.0 # Monthly amount of data retrieved in GB.
+    # monthly_egress_data_transfer_gb:
+      # same_continent: 0.0 # Same continent.
+      # worldwide: 0.0 # Worldwide excluding Asia, Australia.
+      # asia: 0.0 # Asia excluding China, but including Hong Kong.
+      # china: 0.0 # China excluding Hong Kong.
+      # australia: 0.0 # Australia.
   # module.test.google_logging_project_sink.this:
     # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.
   # module.test.google_pubsub_subscription.this:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for `provider_google` version `5.18.0` and `provider_random` version `3.6.0`.
	- Introduced new resources for enhanced cloud cost management, including BigQuery dataset IAM member, service account IAM member, and storage bucket configurations.
	- Implemented a new variable `cloud_cost_management_bucket_location` for specifying cloud cost management bucket locations.
- **Documentation**
	- Updated README with version updates and summary of changes.
- **Tests**
	- Added integration tests with usage metrics for `google_storage_bucket` to evaluate various performance aspects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->