### PR TITLE
Replace `bigquery.admin` with custom role

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See the documentation for setting up a local development environment [here](http
 
 Links to documentation and other resources required to develop and iterate in this repository successfully.
 
+- [gcp-cloud-cost-management](https://docs.datadoghq.com/cloud_cost_management/google_cloud)
 - [gcp-integration](https://docs.datadoghq.com/integrations/google_cloud_platform)
 
 ### 🔍 Tests

--- a/global/README.md
+++ b/global/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.36.1 |
+| <a name="provider_datadog"></a> [datadog](#provider\_datadog) | 3.37.0 |
 | <a name="provider_google"></a> [google](#provider\_google) | 5.18.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
@@ -25,14 +25,14 @@ No modules.
 |------|------|
 | [datadog_integration_gcp_sts.this](https://registry.terraform.io/providers/datadog/datadog/latest/docs/resources/integration_gcp_sts) | resource |
 | [google_bigquery_dataset.billing_export](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset) | resource |
-| [google_bigquery_dataset_iam_member.cloud_cost_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset_iam_member) | resource |
-| [google_logging_project_sink.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
+| [google_bigquery_dataset_iam_member.billing_export](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset_iam_member) | resource |
+| [google_logging_project_sink.integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_project_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
-| [google_pubsub_topic.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
-| [google_pubsub_topic_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
-| [google_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_iam_member.service_account_token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_pubsub_subscription.integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_topic.integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_member.integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
+| [google_service_account.integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.integration](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_storage_bucket.cloud_cost_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_member.cloud_cost_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [random_id.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |

--- a/global/main.tf
+++ b/global/main.tf
@@ -94,10 +94,10 @@ resource "google_storage_bucket_iam_member" "cloud_cost_management" {
 resource "google_project_iam_member" "this" {
   for_each = toset([
     "roles/browser",
-    "roles/bigquery.admin", # TODO: #16 Replace with custom role
     "roles/cloudasset.viewer",
     "roles/compute.viewer",
     "roles/monitoring.viewer",
+    "organizations/163313809793/roles/datadog.cloudCostManagement"
   ])
 
   member  = "serviceAccount:${google_service_account.integration.email}"

--- a/test/fixtures/default_integration/infracost-usage.yml
+++ b/test/fixtures/default_integration/infracost-usage.yml
@@ -47,11 +47,11 @@ resource_type_default_usage:
       # asia: 0.0 # Asia excluding China, but including Hong Kong.
       # china: 0.0 # China excluding Hong Kong.
       # australia: 0.0 # Australia.
-  # module.test.google_logging_project_sink.this:
+  # module.test.google_logging_project_sink.integration:
     # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.
-  # module.test.google_pubsub_subscription.this:
+  # module.test.google_pubsub_subscription.integration:
     # monthly_message_data_tb: 0.0 # Monthly amount of message data pulled by the subscription in TB.
     # storage_gb: 0.0 # Storage for retaining acknowledged messages in GB.
     # snapshot_storage_gb: 0.0 # Snapshot storage for unacknowledged messages in GB.
-  # module.test.google_pubsub_topic.this:
+  # module.test.google_pubsub_topic.integration:
     # monthly_message_data_tb: 0.0 # Monthly amount of message data published to the topic in TB.


### PR DESCRIPTION
Fixes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README.md with a link to the `gcp-cloud-cost-management` documentation.
	- Updated version information for various providers and resource name changes in Google Cloud services in the global README.md.

- **New Features**
	- Introduced a custom role in place of `bigquery.admin` and added a new role for Datadog cloud cost management in the Google Cloud project IAM configuration.

- **Refactor**
	- Renamed resources in the default integration test fixtures to reflect a more integration-specific naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->