### PR TITLE
Enable Google Cloud Armor metrics, events, and logs in Datadog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-symlinks
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.0
+    rev: v1.92.1
     hooks:
       - id: terraform_fmt
 
@@ -29,7 +29,7 @@ repos:
       - id: terraform_docs
 
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.212
+    rev: 3.2.217
     hooks:
       - id: checkov
         verbose: true

--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ terraform test -var="api_key=$DATADOG_API_KEY" -var="app_key=$DATADOG_APP_KEY"
 | api\_key | Datadog API key | `string` | n/a | yes |
 | cloud\_cost\_management\_location | The location for the cloud cost management bucket and Bigquery dataset, only used if enable\_cloud\_cost\_management is true | `string` | `"US"` | no |
 | enable\_cloud\_cost\_management | Whether Datadog collects cloud cost management data from your GCP project, this should only be set to true in a single project | `bool` | `false` | no |
+| host\_filters | A list of host filters to apply to the Datadog GCP integration | `list(string)` | `[]` | no |
 | is\_cspm\_enabled | Whether Datadog collects cloud security posture management resources from your GCP project | `bool` | `false` | no |
+| is\_security\_command\_center\_enabled | When enabled, Datadog will attempt to collect Security Command Center Findings. Note: This requires additional permissions on the service account | `bool` | `false` | no |
 | labels | A map of key/value pairs to assign to the resources being created | `map(string)` | ```{ "system": "datadog" }``` | no |
 | project | The ID of the project in which the resource belongs | `string` | n/a | yes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -13,9 +13,10 @@ terraform {
 # https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/integration_gcp_sts
 
 resource "datadog_integration_gcp_sts" "this" {
-  client_email    = google_service_account.integration.email
-  is_cspm_enabled = var.is_cspm_enabled
-  host_filters    = ["datadog:monitored"]
+  client_email                       = google_service_account.integration.email
+  host_filters                       = var.host_filters
+  is_cspm_enabled                    = var.is_cspm_enabled
+  is_security_command_center_enabled = var.is_security_command_center_enabled
 }
 
 # Google BigQuery Dataset Resource

--- a/variables.tf
+++ b/variables.tf
@@ -16,8 +16,20 @@ variable "enable_cloud_cost_management" {
   default     = false
 }
 
+variable "host_filters" {
+  description = "A list of host filters to apply to the Datadog GCP integration"
+  type        = list(string)
+  default     = []
+}
+
 variable "is_cspm_enabled" {
   description = "Whether Datadog collects cloud security posture management resources from your GCP project"
+  type        = bool
+  default     = false
+}
+
+variable "is_security_command_center_enabled" {
+  description = "When enabled, Datadog will attempt to collect Security Command Center Findings. Note: This requires additional permissions on the service account"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
Fixes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new configuration options for the Datadog GCP integration: `host_filters` allows for tailored filtering of hosts, and `is_security_command_center_enabled` enables the collection of security findings.
  
- **Documentation**
  - Updated the README to include details about the new configuration options for better user guidance.

- **Chores**
  - Updated version specifications for the pre-commit hooks to incorporate the latest bug fixes and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->